### PR TITLE
Update organisers and information about HWC London being hosted online

### DIFF
--- a/src/site/_data/prod/data_attendees.json
+++ b/src/site/_data/prod/data_attendees.json
@@ -1,7 +1,7 @@
 [
   {
     "url": "https://joshvazq.github.io/",
-    "name": "Josu?Š V??zquez Rendo"
+    "name": "Josu?ï¿½ V??zquez Rendo"
   },
   {
     "url": "http://anomalily.net/",
@@ -90,5 +90,13 @@
   {
     "url": "https://tommorris.org",
     "name": "Tom Morris"
+  },
+  {
+    "url": "https://jamesg.blog",
+    "name": "James"
+  },
+  {
+    "url": "https://marksuth.dev",
+    "name": "Mark"
   }
 ]

--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -1,7 +1,7 @@
 <footer>
   <p>
     <abbr title="Homebrew Website Club">HWC</abbr> London is organised by
-    <a class="h-card" href="https://jamesg.blog">James</a> and <a class="h-card" href="https://www.ohhelloana.blog/">Mark</a>.
+    <a class="h-card" href="https://jamesg.blog">James</a> and <a class="h-card" href="https://marksuth.dev/">Mark</a>.
   </p>
   <p>
     We would like to thank

--- a/src/site/_includes/footer.njk
+++ b/src/site/_includes/footer.njk
@@ -1,7 +1,12 @@
 <footer>
   <p>
     <abbr title="Homebrew Website Club">HWC</abbr> London is organised by
-    <a class="h-card" href="https://calumryan.com/">Calum Ryan</a> and <a class="h-card" href="https://www.ohhelloana.blog/">Ana Rodrigues</a>.
+    <a class="h-card" href="https://jamesg.blog">James</a> and <a class="h-card" href="https://www.ohhelloana.blog/">Mark</a>.
+  </p>
+  <p>
+    We would like to thank
+    <a class="h-card" href="https://calumryan.com/">Calum Ryan</a> and <a class="h-card" href="https://www.ohhelloana.blog/">Ana Rodrigues</a>
+    for previously hosting the meetup.
   </p>
   <p>Read our <a href="/code-of-conduct#intro">Code of conduct</a>.</p>
   <p>This page was generated on {{ site.buildTime | dateDisplay('LLL d, yyyy - HH:mm') }}</p>

--- a/src/site/index.md
+++ b/src/site/index.md
@@ -6,7 +6,7 @@ layout: layouts/base.njk
 
 ## Join us at our weekly online meetup
 
-_Whilst we're unable to meetup in-person due to the ongoing Covid-19 pandemic, we're running our meetup online bi-weekly over Zoom. We're open to anyone who'd like to join us anywhere in Europe and beyond from 18:00 to 20:00 (British Summer Time)._
+_The HWC London / Europe meetup is now hosted online. We're open to anyone who'd like to join us anywhere in Europe and beyond from 18:00 to 20:00 (British Summer Time)._
 
 Finish that blog post you've been working on. Demos of personal websites and technology. Discussion around the independent web. Join a community with like-minded interests. Bring friends that want a personal site!
 

--- a/src/site/people.md
+++ b/src/site/people.md
@@ -26,6 +26,8 @@ attendees:
   - https://martinheathsjournal.blog/
   - https://mey.vn/
   - https://barryfrost.com/
+  - https://marksuth.dev/
+  - https://jamesg.blog/
 ---
 
 # People


### PR DESCRIPTION
This PR contains three changes:

1. @marksuth and @capjamesg are added as attendees.
2. The index.html file is updated to be clear the event is hosted online in the first paragraph of text.
3. The footer is updated to reflect that the event is now organized by @capjamesg and @marksuth.

This should be the first of a few commits to update the HWC London website.