### PR TITLE
Update meetup page and navigation bar item

### DIFF
--- a/src/site/_includes/header.njk
+++ b/src/site/_includes/header.njk
@@ -1,7 +1,7 @@
 <nav class="navigation-wrapper">
   <ul>
     <li class="nav-normal"><a href="/about#intro"><span>About</span></a></li>
-    <li class="nav-normal"><a href="/meetups#intro"><span>Past meetups</span></a></li>
+    <li class="nav-normal"><a href="/meetups#intro"><span>Meetups</span></a></li>
     <li class="nav-normal"><a href="/people#intro"><span>People</span></a></li>
   </ul>
 </nav>

--- a/src/site/_includes/layouts/listing.njk
+++ b/src/site/_includes/layouts/listing.njk
@@ -12,7 +12,12 @@
 
     <main id="intro">
       <article class="container">
-        <h1>Past meetups</h1>
+        <h1>Meetups</h1>
+
+        <div class="event-notification">
+          <p>Our upcoming events are now listed on the <a href="https://events.indieweb.org">IndieWeb community events</a> page.</p>
+          <p>Check regularly to find the latest HWC London / Europe meetups and other events.</p>
+        </div>
         <ul class="listing">
         {%- for page in collections.meetup | reverse -%}
         <li>

--- a/src/site/_includes/postcss/_listing.css
+++ b/src/site/_includes/postcss/_listing.css
@@ -20,3 +20,10 @@
   width: 100%;
   height: 100%;
 }
+
+.event-notification {
+  padding: 0.5em;
+  background: #2d2d2d;
+  box-shadow: $shadow-1;
+  border: 2px solid $iw-yellow;
+}


### PR DESCRIPTION
This commit includes changes to:

1. Rename "past meetups" to "meetups"
2. Show a box on the "meetups" page to indicate our meetups are now displayed on the IndieWeb events page.