### PR TITLE
Add home link to navigation bar

### DIFF
--- a/src/site/_includes/header.njk
+++ b/src/site/_includes/header.njk
@@ -1,5 +1,6 @@
 <nav class="navigation-wrapper">
   <ul>
+    <li class="nav-normal"><a href="/"><span>Home</span></a></li>
     <li class="nav-normal"><a href="/about#intro"><span>About</span></a></li>
     <li class="nav-normal"><a href="/meetups#intro"><span>Meetups</span></a></li>
     <li class="nav-normal"><a href="/people#intro"><span>People</span></a></li>


### PR DESCRIPTION
At the moment, navigating back to the root page on the website is not intuitive. This PR adds a "Home" link to the navigation bar to assist navigation to the home page.